### PR TITLE
fix(ios): Use version instead of branch for SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
             targets: ["DeviceSecurityDetectPlugin"])
     ],
     dependencies: [
-        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", branch: "main")
+        .package(url: "https://github.com/ionic-team/capacitor-swift-pm.git", from: "6.0.0")
     ],
     targets: [
         .target(


### PR DESCRIPTION
main branch of capacitor-swift-pm has Capacitor 7 at the moment, but the plugin is still using Capacitor 6, so it will cause issues.
Use version 6 instead of main branch.